### PR TITLE
idempotent initialisation, hint for adding init hooks

### DIFF
--- a/src/reveal/core.cljs
+++ b/src/reveal/core.cljs
@@ -29,6 +29,8 @@
   "Get all slides, set them as innerHTML and reinitialize Reveal.js"
   []
   (set! (.. (gdom/getElement "slides") -innerHTML) (convert))
-  (.initialize js/Reveal options)
-  (.setState js/Reveal (.getState js/Reveal)))
+  (let [state (and (.isReady js/Reveal) (.getState js/Reveal))]
+    (-> (.initialize js/Reveal options)
+        (.then #(when state (.setState js/Reveal state)))
+        (.then (fn [] "call your own init code from here")))))
 (main)


### PR DESCRIPTION
Hi,

Thanks for this great library.

I was getting the following error when loading my presentation:
```
reveal.js:1650 Uncaught TypeError: Cannot read properties of undefined (reading 'classList')
    at ot (reveal.js:1650:27)
    at it (reveal.js:1280:12)
    at Function.Lt [as setState] (reveal.js:2154:4)
    at reveal$core$main (core.cljs:34:14)
    at core.cljs:45:2
```

I believe this is due to a potential race condition on initialisation. This change uses promise chaining to avoid that, and also indicates a convenient place to add your own initialisation hooks.

Thanks