### PR TITLE
syncing speaker notes to speaker window after figwheel reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ clean:
 	@echo ":: Clean"
 	rm -rf target/
 	rm -rf resources/public/node_modules
+	rm -rf resources/public/cljs-out
 
 web: install
 	mkdir -p resources/public/cljs-out

--- a/src/reveal/core.cljs
+++ b/src/reveal/core.cljs
@@ -32,5 +32,12 @@
   (let [state (and (.isReady js/Reveal) (.getState js/Reveal))]
     (-> (.initialize js/Reveal options)
         (.then #(when state (.setState js/Reveal state)))
+        (.then #(if (.isSpeakerNotes js/Reveal)
+                  ;; disable figwheel connection for speaker notes
+                  (when (.hasOwnProperty js/window "figwheel")
+                    (set! (.-connect js/figwheel.repl) (constantly "Disabled for speaker notes")))
+
+                  ;; trigger an event which will update the speaker notes
+                  (.dispatchEvent js/Reveal (clj->js {:type "resumed"}))))
         (.then (fn [] "call your own init code from here")))))
 (main)

--- a/src/reveal/slides.cljs
+++ b/src/reveal/slides.cljs
@@ -5,7 +5,9 @@
    [:h1 "reveal-cljs"]
    [:h5 "Create awesome Web-Presentations with ClojureScript"]
    [:p "Based on "
-    [:a {:href "http://lab.hakim.se/reveal-js/"} "reveal.js"]]])
+    [:a {:href "http://lab.hakim.se/reveal-js/"} "reveal.js"]]
+   [:aside.notes
+    [:ul [:li "Some notes"]]]])
 
 (def ^:private argument
   [:div.argument


### PR DESCRIPTION
Hi,

Reveal.js [seems to support reloading of speaker notes](https://github.com/hakimel/reveal.js/issues/2822) but this wasn't working in my reveal-cljs project after a figwheel reload (I guess the reveal method of hot reloading is less incremental than figwheel).

This change does two things:
1. Prevents figwheel from unnecessarily opening a websocket in the speaker slides window
2. Posts a message to the speaker notes window after the reload with the new notes content

NB The message post was reverse-engineered from the [Reveal notes plugin code](https://github.com/hakimel/reveal.js/blob/master/plugin/notes/plugin.js#L108-L156) and doesn't use an exposed API, so it's not as robust as I'd like, but I couldn't find any other way to do it.

Thanks