### PR TITLE
Change (1) Makefile, and (2) deps.edn; add (3) resources/logback.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 
 repl:
 	@echo ":: Start an interactive REPL"
-	clj -A:fig
+	clj -M:fig
 
 clean:
 	@echo ":: Clean"
@@ -24,4 +24,4 @@ web: install
 
 outdated:
 	@echo ":: Check for old dependencies"
-	clojure -Aoutdated -a outdated
+	clojure -M:outdated

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/clojurescript {:mvn/version "1.11.60"}
+        org.slf4j/slf4j-api {:mvn/version "2.0.7"}
+        ch.qos.logback/logback-classic {:mvn/version "1.4.8"}
         com.bhauman/figwheel-main {:mvn/version "0.2.18"}
         com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
         org.clojure/core.async {:mvn/version "1.6.673"}
@@ -8,5 +10,5 @@
  :aliases {:fig {:main-opts ["-m" "figwheel.main" "-b" "dev" "--repl"]}
            :fig/simple {:main-opts ["-m" "figwheel.main" "-O" "simple" "-bo" "dev"]}
            :fig/min {:main-opts ["-m" "figwheel.main" "-O" "advanced" "-bo" "dev"]}
-           :outdated {:extra-deps {olical/depot {:mvn/version "2.0.1"}}
+           :outdated {:extra-deps {olical/depot {:mvn/version "2.3.0"}}
                       :main-opts ["-m" "depot.outdated.main"]}}}

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <!-- Root logger: Log level set to WARNING -->
+  <root level="WARN">
+    <appender-ref ref="CONSOLE" />
+  </root>
+
+  <!-- Console appender: Prints logs to the console -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+</configuration>


### PR DESCRIPTION
(1) The Makefile changes remove the use of deprecated -A flag in favor of -M.

(2a) The deps.edn changes update the olical/depot dependency for outdated dependency management.

(2b) olical/depot expects there to be a logger, so two additional dependencies, slf4j and logback-classic, were added in order to prevent the errors when running `make outdated`

(3) By default, logback-classic log level is DEBUG, which results in unnecessary logging, so the resources/logback.xml file deals with that, as well as standardizes log formatting to a common pattern that can be searched, as the regex is defined in the file.